### PR TITLE
Update baseURL to relace.run and add SDK usage docs

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -22,7 +22,7 @@
       "description": "Server for code embedding endpoints"
     },
     {
-      "url": "https://api.relace.ai",
+      "url": "https://api.relace.run",
       "description": "Server for general infrastructure"
     }
   ],
@@ -504,7 +504,7 @@
         "description": "Create a new repository",
         "servers": [
           {
-            "url": "https://api.relace.ai"
+            "url": "https://api.relace.run"
           }
         ],
         "requestBody": {
@@ -555,7 +555,7 @@
         "description": "List all repositories",
         "servers": [
           {
-            "url": "https://api.relace.ai"
+            "url": "https://api.relace.run"
           }
         ],
         "parameters": [
@@ -634,7 +634,7 @@
         "description": "Delete a repository",
         "servers": [
           {
-            "url": "https://api.relace.ai"
+            "url": "https://api.relace.run"
           }
         ],
         "parameters": [
@@ -680,7 +680,7 @@
         "description": "Update repository content",
         "servers": [
           {
-            "url": "https://api.relace.ai"
+            "url": "https://api.relace.run"
           }
         ],
         "parameters": [
@@ -754,7 +754,7 @@
         "description": "Retrieve relevant files from repository using semantic search",
         "servers": [
           {
-            "url": "https://api.relace.ai"
+            "url": "https://api.relace.run"
           }
         ],
         "parameters": [
@@ -828,7 +828,7 @@
         "description": "Ask a question about the repository content",
         "servers": [
           {
-            "url": "https://api.relace.ai"
+            "url": "https://api.relace.run"
           }
         ],
         "parameters": [
@@ -902,7 +902,7 @@
         "description": "Search for specific text patterns in repository files",
         "servers": [
           {
-            "url": "https://api.relace.ai"
+            "url": "https://api.relace.run"
           }
         ],
         "parameters": [

--- a/api-reference/repos/ask.mdx
+++ b/api-reference/repos/ask.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Ask'
-api: 'POST https://api.relace.ai/v1/repo/{repo_id}/ask'
+api: 'POST https://api.relace.run/v1/repo/{repo_id}/ask'
 description: 'Ask natural language questions about repo content'
 ---
 
@@ -26,7 +26,7 @@ description: 'Ask natural language questions about repo content'
 <RequestExample>
 
 ```bash cURL
-curl -X POST https://api.relace.ai/v1/repo/123e4567-e89b-12d3-a456-426614174000/ask \
+curl -X POST https://api.relace.run/v1/repo/123e4567-e89b-12d3-a456-426614174000/ask \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -38,7 +38,7 @@ curl -X POST https://api.relace.ai/v1/repo/123e4567-e89b-12d3-a456-426614174000/
 import requests
 
 repo_id = "123e4567-e89b-12d3-a456-426614174000"
-url = f"https://api.relace.ai/v1/repo/{repo_id}/ask"
+url = f"https://api.relace.run/v1/repo/{repo_id}/ask"
 headers = {
     "Authorization": "Bearer YOUR_API_KEY",
     "Content-Type": "application/json"
@@ -49,6 +49,33 @@ data = {
 
 response = requests.post(url, headers=headers, json=data)
 print(response.json())
+```
+
+```ts TypeScript SDK
+import createRelaceClient from '@relace-ai/agent-client'
+
+const client = createRelaceClient({ apiKey: process.env.RELACE_API_KEY! })
+
+const { data } = await client.POST('/repo/{repo_id}/ask', {
+  params: { path: { repo_id: '123e4567-e89b-12d3-a456-426614174000' } },
+  body: { query: 'How does the user authentication system work?' },
+})
+console.log(data?.answer)
+```
+
+```python Python SDK
+from relace_agent_client import AuthenticatedClient
+from relace_agent_client.api.default import ask_question_repo_repo_id_ask_post
+from relace_agent_client.models import RepoAskRequest
+
+client = AuthenticatedClient(base_url="https://api.relace.run/v1", token="YOUR_API_KEY")
+with client as c:
+    res = ask_question_repo_repo_id_ask_post.sync(
+        client=c,
+        repo_id="123e4567-e89b-12d3-a456-426614174000",
+        body=RepoAskRequest(query="How does the user authentication system work?"),
+    )
+print(res.answer)
 ```
 
 </RequestExample>

--- a/api-reference/repos/clone.mdx
+++ b/api-reference/repos/clone.mdx
@@ -1,8 +1,12 @@
 ---
 title: 'Clone Repo'
-api: 'GET https://api.relace.ai/v1/repo/{repo_id}/clone'
-description: 'Clone a repository and get all its files'
+api: 'GET https://api.relace.run/v1/repo/{repo_id}/clone'
+description: 'Download all files and content from a repository'
 ---
+
+<Note>
+  This endpoint provides a convenient way to download all files from a repository at once. For selective file retrieval, consider using the [retrieve endpoint](/api-reference/repos/retrieve) with `include_content: true`.
+</Note>
 
 ## Path Parameters
 
@@ -13,13 +17,13 @@ description: 'Clone a repository and get all its files'
 ## Response
 
 <ResponseField name="files" type="array">
-  Array of all files in the repository
+  Array of all files in the repository with their complete content
   
   <Expandable title="properties" defaultOpen={false}>
     <ResponseField name="filename" type="string">
       Path to the file within the repo
     </ResponseField>
-    
+
     <ResponseField name="content" type="string">
       Full content of the file
     </ResponseField>
@@ -29,7 +33,7 @@ description: 'Clone a repository and get all its files'
 <RequestExample>
 
 ```bash cURL
-curl -X GET https://api.relace.ai/v1/repo/123e4567-e89b-12d3-a456-426614174000/clone \
+curl -X GET https://api.relace.run/v1/repo/123e4567-e89b-12d3-a456-426614174000/clone \
   -H "Authorization: Bearer YOUR_API_KEY"
 ```
 
@@ -37,13 +41,39 @@ curl -X GET https://api.relace.ai/v1/repo/123e4567-e89b-12d3-a456-426614174000/c
 import requests
 
 repo_id = "123e4567-e89b-12d3-a456-426614174000"
-url = f"https://api.relace.ai/v1/repo/{repo_id}/clone"
+url = f"https://api.relace.run/v1/repo/{repo_id}/clone"
 headers = {
     "Authorization": "Bearer YOUR_API_KEY"
 }
 
 response = requests.get(url, headers=headers)
 print(response.json())
+```
+
+```ts TypeScript SDK
+import createRelaceClient from '@relace-ai/agent-client'
+
+const client = createRelaceClient({ apiKey: process.env.RELACE_API_KEY! })
+
+const repo_id = '123e4567-e89b-12d3-a456-426614174000'
+const { data, error } = await client.GET('/repo/{repo_id}/clone', {
+  params: { path: { repo_id } },
+})
+if (error) throw error
+for (const f of data?.files ?? []) {
+  console.log(f.filename, f.content.length)
+}
+```
+
+```python Python SDK
+from relace_agent_client import AuthenticatedClient
+from relace_agent_client.api.default import clone_repo_repo_repo_id_clone_get
+
+client = AuthenticatedClient(base_url="https://api.relace.run/v1", token="YOUR_API_KEY")
+with client as c:
+    clone = clone_repo_repo_repo_id_clone_get.sync(client=c, repo_id="123e4567-e89b-12d3-a456-426614174000")
+for f in (clone.files or []):
+    print(f.filename, len(f.content))
 ```
 
 </RequestExample>

--- a/api-reference/repos/create.mdx
+++ b/api-reference/repos/create.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Create Repo'
-api: 'POST https://api.relace.ai/v1/repo'
+api: 'POST https://api.relace.run/v1/repo'
 description: 'Create a new repo from files or a GitHub repo.'
 ---
 
@@ -69,7 +69,7 @@ description: 'Create a new repo from files or a GitHub repo.'
 <RequestExample>
 
 ```bash cURL
-curl -X POST https://api.relace.ai/v1/repo \
+curl -X POST https://api.relace.run/v1/repo \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
     -d '{
@@ -97,7 +97,7 @@ curl -X POST https://api.relace.ai/v1/repo \
 ```python Python
 import requests
 
-url = "https://api.relace.ai/v1/repo"
+url = "https://api.relace.run/v1/repo"
 headers = {
     "Authorization": "Bearer YOUR_API_KEY",
     "Content-Type": "application/json"
@@ -126,6 +126,43 @@ data = {
 
 response = requests.post(url, headers=headers, json=data)
 print(response.json())
+```
+
+```ts TypeScript SDK
+import createRelaceClient from '@relace-ai/agent-client'
+
+const client = createRelaceClient({ apiKey: process.env.RELACE_API_KEY! })
+
+const { data, error } = await client.POST('/repo', {
+  body: {
+    source: {
+      type: 'files',
+      files: [
+        { filename: 'src/search.ts', content: '// ...' },
+        { filename: 'src/types.ts', content: '// ...' },
+      ],
+    },
+    metadata: { name: 'my-codebase', id: 'my-internal-id' },
+  },
+})
+if (error) throw error
+console.log(data)
+```
+
+```python Python SDK
+from relace_agent_client import AuthenticatedClient
+from relace_agent_client.api.default import create_repo_repo_post
+from relace_agent_client.models import RepoCreateRequest, RepoCreateFilesSource, File as ModelFile
+
+client = AuthenticatedClient(base_url="https://api.relace.run/v1", token="YOUR_API_KEY")
+files = [
+    ModelFile(filename="src/search.ts", content="// ..."),
+    ModelFile(filename="src/types.ts", content="// ..."),
+]
+req = RepoCreateRequest(source=RepoCreateFilesSource(type_="files", files=files))
+with client as c:
+    created = create_repo_repo_post.sync(client=c, body=req)
+print(created)
 ```
 
 </RequestExample>

--- a/api-reference/repos/delete.mdx
+++ b/api-reference/repos/delete.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Delete Repo'
-api: 'DELETE https://api.relace.ai/v1/repo/{repo_id}'
+api: 'DELETE https://api.relace.run/v1/repo/{repo_id}'
 description: 'Delete a repo and all its associated data'
 ---
 
@@ -17,7 +17,7 @@ This endpoint returns no content on successful deletion.
 <RequestExample>
 
 ```bash cURL
-curl -X DELETE https://api.relace.ai/v1/repo/123e4567-e89b-12d3-a456-426614174000 \
+curl -X DELETE https://api.relace.run/v1/repo/123e4567-e89b-12d3-a456-426614174000 \
   -H "Authorization: Bearer YOUR_API_KEY"
 ```
 
@@ -25,13 +25,35 @@ curl -X DELETE https://api.relace.ai/v1/repo/123e4567-e89b-12d3-a456-42661417400
 import requests
 
 repo_id = "123e4567-e89b-12d3-a456-426614174000"
-url = f"https://api.relace.ai/v1/repo/{repo_id}"
+url = f"https://api.relace.run/v1/repo/{repo_id}"
 headers = {
     "Authorization": "Bearer YOUR_API_KEY"
 }
 
 response = requests.delete(url, headers=headers)
 print(f"Status: {response.status_code}")
+```
+
+```ts TypeScript SDK
+import createRelaceClient from '@relace-ai/agent-client'
+
+const client = createRelaceClient({ apiKey: process.env.RELACE_API_KEY! })
+
+const repo_id = '123e4567-e89b-12d3-a456-426614174000'
+const { response, error } = await client.DELETE('/repo/{repo_id}', {
+  params: { path: { repo_id } },
+})
+if (error) throw error
+console.log('Status:', response.status)
+```
+
+```python Python SDK
+from relace_agent_client import AuthenticatedClient
+from relace_agent_client.api.default import delete_repo_repo_repo_id_delete
+
+client = AuthenticatedClient(base_url="https://api.relace.run/v1", token="YOUR_API_KEY")
+with client as c:
+    delete_repo_repo_repo_id_delete.sync(client=c, repo_id="123e4567-e89b-12d3-a456-426614174000")
 ```
 
 </RequestExample>

--- a/api-reference/repos/get.mdx
+++ b/api-reference/repos/get.mdx
@@ -1,0 +1,90 @@
+---
+title: 'Get Repo Details'
+api: 'GET https://api.relace.run/v1/repo/{repo_id}'
+description: 'Retrieve details about a specific repository'
+---
+
+## Path Parameters
+
+<ParamField path="repo_id" type="string" required>
+  UUID of the repo to retrieve
+</ParamField>
+
+## Response
+
+<ResponseField name="repo_id" type="string">
+  Unique identifier for the repo
+</ResponseField>
+
+<ResponseField name="created_at" type="string">
+  Time when the repo was originally created (ISO 8601 timestamp)
+</ResponseField>
+
+<ResponseField name="updated_at" type="string">
+  Time when the repo was last modified (ISO 8601 timestamp)
+</ResponseField>
+
+<ResponseField name="metadata" type="object">
+  Custom key/value pairs associated with the repo
+</ResponseField>
+
+<RequestExample>
+
+```bash cURL
+curl -X GET https://api.relace.run/v1/repo/123e4567-e89b-12d3-a456-426614174000 \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+```python Python
+import requests
+
+repo_id = "123e4567-e89b-12d3-a456-426614174000"
+url = f"https://api.relace.run/v1/repo/{repo_id}"
+headers = {
+    "Authorization": "Bearer YOUR_API_KEY"
+}
+
+response = requests.get(url, headers=headers)
+print(response.json())
+```
+
+```ts TypeScript SDK
+import createRelaceClient from '@relace-ai/agent-client'
+
+const client = createRelaceClient({ apiKey: process.env.RELACE_API_KEY! })
+
+const repo_id = '123e4567-e89b-12d3-a456-426614174000'
+const { data, error } = await client.GET('/repo/{repo_id}', {
+  params: { path: { repo_id } },
+})
+if (error) throw error
+console.log(data)
+```
+
+```python Python SDK
+from relace_agent_client import AuthenticatedClient
+from relace_agent_client.api.default import get_repo_repo_repo_id_get
+
+client = AuthenticatedClient(base_url="https://api.relace.run/v1", token="YOUR_API_KEY")
+with client as c:
+    repo = get_repo_repo_repo_id_get.sync(client=c, repo_id="123e4567-e89b-12d3-a456-426614174000")
+print(repo)
+```
+
+</RequestExample>
+
+<ResponseExample>
+
+```json Response
+{
+  "repo_id": "123e4567-e89b-12d3-a456-426614174000",
+  "created_at": "2024-01-15T10:30:00Z",
+  "updated_at": "2024-01-15T11:15:00Z", 
+  "metadata": {
+    "name": "my-project",
+    "description": "A sample project"
+  }
+}
+```
+
+</ResponseExample>

--- a/api-reference/repos/list.mdx
+++ b/api-reference/repos/list.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'List Repos'
-api: 'GET https://api.relace.ai/v1/repo'
+api: 'GET https://api.relace.run/v1/repo'
 description: 'Get a paginated list of all repos you own.'
 ---
 
@@ -59,14 +59,14 @@ description: 'Get a paginated list of all repos you own.'
 <RequestExample>
 
 ```bash cURL
-curl -X GET "https://api.relace.ai/v1/repo?page_size=10" \
+curl -X GET "https://api.relace.run/v1/repo?page_size=10" \
   -H "Authorization: Bearer YOUR_API_KEY"
 ```
 
 ```python Python
 import requests
 
-url = "https://api.relace.ai/v1/repo"
+url = "https://api.relace.run/v1/repo"
 headers = {
     "Authorization": "Bearer YOUR_API_KEY"
 }
@@ -76,6 +76,28 @@ params = {
 
 response = requests.get(url, headers=headers, params=params)
 print(response.json())
+```
+
+```ts TypeScript SDK
+import createRelaceClient from '@relace-ai/agent-client'
+
+const client = createRelaceClient({ apiKey: process.env.RELACE_API_KEY! })
+
+const res = await client.GET('/repo', {
+  params: { query: { page_size: 10 } },
+})
+if (res.error) throw res.error
+console.log(res.data)
+```
+
+```python Python SDK
+from relace_agent_client import AuthenticatedClient
+from relace_agent_client.api.default import list_repo_metadata_repo_get
+
+client = AuthenticatedClient(base_url="https://api.relace.run/v1", token="YOUR_API_KEY")
+with client as c:
+    page = list_repo_metadata_repo_get.sync(client=c, page_size=10)
+    print(page)
 ```
 
 </RequestExample>

--- a/api-reference/repos/retrieve.mdx
+++ b/api-reference/repos/retrieve.mdx
@@ -1,8 +1,12 @@
 ---
 title: 'Retrieve'
-api: 'POST https://api.relace.ai/v1/repo/{repo_id}/retrieve'
+api: 'POST https://api.relace.run/v1/repo/{repo_id}/retrieve'
 description: 'Two-stage codebase retrieval using semantic search'
 ---
+
+<Note>
+  The retrieve endpoint provides advanced semantic search capabilities with additional parameters for fine-tuning results. For complete parameter documentation, see below.
+</Note>
 
 ## Path Parameters
 
@@ -37,11 +41,11 @@ description: 'Two-stage codebase retrieval using semantic search'
     <ResponseField name="filename" type="string">
       Path to the file within the repo
     </ResponseField>
-    
+
     <ResponseField name="score" type="number">
       Relevance score between 0.0 and 1.0
     </ResponseField>
-    
+
     <ResponseField name="content" type="string">
       File content (only included when include_content=true)
     </ResponseField>
@@ -52,7 +56,7 @@ description: 'Two-stage codebase retrieval using semantic search'
 <RequestExample>
 
 ```bash cURL
-curl -X POST https://api.relace.ai/v1/repo/123e4567-e89b-12d3-a456-426614174000/retrieve \
+curl -X POST https://api.relace.run/v1/repo/123e4567-e89b-12d3-a456-426614174000/retrieve \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -67,7 +71,7 @@ curl -X POST https://api.relace.ai/v1/repo/123e4567-e89b-12d3-a456-426614174000/
 import requests
 
 repo_id = "123e4567-e89b-12d3-a456-426614174000"
-url = f"https://api.relace.ai/v1/repo/{repo_id}/retrieve"
+url = f"https://api.relace.run/v1/repo/{repo_id}/retrieve"
 headers = {
     "Authorization": "Bearer YOUR_API_KEY",
     "Content-Type": "application/json"
@@ -81,6 +85,38 @@ data = {
 
 response = requests.post(url, headers=headers, json=data)
 print(response.json())
+```
+
+```ts TypeScript SDK
+import createRelaceClient from '@relace-ai/agent-client'
+
+const client = createRelaceClient({ apiKey: process.env.RELACE_API_KEY! })
+
+const { data } = await client.POST('/repo/{repo_id}/retrieve', {
+  params: { path: { repo_id: '123e4567-e89b-12d3-a456-426614174000' } },
+  body: {
+    query: 'authentication and user login functionality',
+    score_threshold: 0.3,
+    token_limit: 30000,
+    include_content: true,
+  },
+})
+console.log(data?.results?.map((r) => ({ file: r.filename, score: r.score })))
+```
+
+```python Python SDK
+from relace_agent_client import AuthenticatedClient
+from relace_agent_client.api.default import retrieve_relevant_content_repo_repo_id_retrieve_post
+from relace_agent_client.models import RepoRetrieveRequest
+
+client = AuthenticatedClient(base_url="https://api.relace.run/v1", token="YOUR_API_KEY")
+with client as c:
+    r = retrieve_relevant_content_repo_repo_id_retrieve_post.sync(
+        client=c,
+        repo_id="123e4567-e89b-12d3-a456-426614174000",
+        body=RepoRetrieveRequest(query="authentication and user login functionality", include_content=True, score_threshold=0.3),
+    )
+print(r)
 ```
 
 </RequestExample>

--- a/api-reference/repos/search.mdx
+++ b/api-reference/repos/search.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Search'
-api: 'POST https://api.relace.ai/v1/repo/{repo_id}/search'
+api: 'POST https://api.relace.run/v1/repo/{repo_id}/search'
 description: 'Search for specific text patterns in repo files'
 ---
 
@@ -26,19 +26,19 @@ description: 'Search for specific text patterns in repo files'
     <ResponseField name="filename" type="string">
       Path to the file within the repo
     </ResponseField>
-    
+
     <ResponseField name="line_number" type="integer">
       Line number where the match was found
     </ResponseField>
-    
+
     <ResponseField name="line_content" type="string">
       Content of the matching line
     </ResponseField>
-    
+
     <ResponseField name="match_start" type="integer">
       Starting position of the match in the line
     </ResponseField>
-    
+
     <ResponseField name="match_end" type="integer">
       Ending position of the match in the line
     </ResponseField>
@@ -49,7 +49,7 @@ description: 'Search for specific text patterns in repo files'
 <RequestExample>
 
 ```bash cURL
-curl -X POST https://api.relace.ai/v1/repo/123e4567-e89b-12d3-a456-426614174000/search \
+curl -X POST https://api.relace.run/v1/repo/123e4567-e89b-12d3-a456-426614174000/search \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -61,7 +61,7 @@ curl -X POST https://api.relace.ai/v1/repo/123e4567-e89b-12d3-a456-426614174000/
 import requests
 
 repo_id = "123e4567-e89b-12d3-a456-426614174000"
-url = f"https://api.relace.ai/v1/repo/{repo_id}/search"
+url = f"https://api.relace.run/v1/repo/{repo_id}/search"
 headers = {
     "Authorization": "Bearer YOUR_API_KEY",
     "Content-Type": "application/json"
@@ -73,6 +73,10 @@ data = {
 response = requests.post(url, headers=headers, json=data)
 print(response.json())
 ```
+
+{/* TypeScript SDK for /search is not yet available in the generated client. Use cURL or a custom fetch for now. */}
+
+{/* Python SDK for /search is not yet available in the generated client. Use cURL or HTTP client for now. */}
 
 </RequestExample>
 
@@ -89,7 +93,7 @@ print(response.json())
       "match_end": 14
     },
     {
-      "filename": "src/middleware.py", 
+      "filename": "src/middleware.py",
       "line_number": 28,
       "line_content": "    # Check if user is authenticated",
       "match_start": 22,

--- a/api-reference/repos/update.mdx
+++ b/api-reference/repos/update.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Update Repo'
-api: 'POST https://api.relace.ai/v1/repo/{repo_id}/update'
+api: 'POST https://api.relace.run/v1/repo/{repo_id}/update'
 description: 'Update repo content with files or sync from Git.'
 ---
 
@@ -24,75 +24,75 @@ description: 'Update repo content with files or sync from Git.'
   `"diff"` for specific operations
 </ParamField>
 
-  <Tabs>
-    <Tab title="Git">
-      <ParamField body="url" type="string" required>
-        Git repo URL to sync from
-      </ParamField>
-      
-      <ParamField body="branch" type="string">
-        Specific branch to sync (optional)
-      </ParamField>
-    </Tab>
-    
-    <Tab title="Files">
-      <ParamField body="files" type="array" required>
+<Tabs>
+  <Tab title="Git">
+    <ParamField body="url" type="string" required>
+      Git repo URL to sync from
+    </ParamField>
+
+    <ParamField body="branch" type="string">
+      Specific branch to sync (optional)
+    </ParamField>
+  </Tab>
+
+  <Tab title="Files">
+    <ParamField body="files" type="array" required>
         Array of file objects that will completely replace the repo content. Any files not included will be deleted from the repo.
         
-        <Expandable title="properties" defaultOpen={false}>
+      <Expandable title="properties" defaultOpen={false}>
         <ParamField body="filename" type="string" required>
           The path and filename for the file
         </ParamField>
-        
+
         <ParamField body="content" type="string" required>
           The content of the file
         </ParamField>
-        </Expandable>
-      </ParamField>
-    </Tab>
-    
-    <Tab title="Diff">
-      <ParamField body="operations" type="array" required>
-        Array of file operations to perform
+      </Expandable>
+    </ParamField>
+  </Tab>
+
+  <Tab title="Diff">
+    <ParamField body="operations" type="array" required>
+      Array of file operations to perform
         
-        <Expandable title="properties" defaultOpen={false}>
+      <Expandable title="properties" defaultOpen={false}>
         <ParamField body="type" type="string" required>
           Operation type: `"write"` to create/update, `"rename"` to change filename, or `"delete"` to remove
           
           <Expandable title="operation-specific properties" defaultOpen={false}>
-          <Tabs>
-            <Tab title="Write">
-              <ParamField body="filename" type="string" required>
-                The path and filename for the file
-              </ParamField>
-              
-              <ParamField body="content" type="string" required>
-                The content of the file
-              </ParamField>
-            </Tab>
-            
-            <Tab title="Rename">
-              <ParamField body="old_filename" type="string" required>
-                The current path and filename
-              </ParamField>
-              
-              <ParamField body="new_filename" type="string" required>
-                The new path and filename
-              </ParamField>
-            </Tab>
-            
-            <Tab title="Delete">
-              <ParamField body="filename" type="string" required>
-                The path and filename to delete
-              </ParamField>
-            </Tab>
-          </Tabs>
+            <Tabs>
+              <Tab title="Write">
+                <ParamField body="filename" type="string" required>
+                  The path and filename for the file
+                </ParamField>
+
+                <ParamField body="content" type="string" required>
+                  The content of the file
+                </ParamField>
+              </Tab>
+
+              <Tab title="Rename">
+                <ParamField body="old_filename" type="string" required>
+                  The current path and filename
+                </ParamField>
+
+                <ParamField body="new_filename" type="string" required>
+                  The new path and filename
+                </ParamField>
+              </Tab>
+
+              <Tab title="Delete">
+                <ParamField body="filename" type="string" required>
+                  The path and filename to delete
+                </ParamField>
+              </Tab>
+            </Tabs>
           </Expandable>
         </ParamField>
-        </Expandable>
-      </ParamField>
-    </Tab>
-  </Tabs>
+      </Expandable>
+    </ParamField>
+  </Tab>
+</Tabs>
 
   </Expandable>
 </ParamField>
@@ -106,7 +106,7 @@ description: 'Update repo content with files or sync from Git.'
 <RequestExample>
 
 ```bash cURL
-curl -X POST https://api.relace.ai/v1/repo/123e4567-e89b-12d3-a456-426614174000/update \
+curl -X POST https://api.relace.run/v1/repo/123e4567-e89b-12d3-a456-426614174000/update \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -136,7 +136,7 @@ curl -X POST https://api.relace.ai/v1/repo/123e4567-e89b-12d3-a456-426614174000/
 import requests
 
 repo_id = "123e4567-e89b-12d3-a456-426614174000"
-url = f"https://api.relace.ai/v1/repo/{repo_id}/update"
+url = f"https://api.relace.run/v1/repo/{repo_id}/update"
 
 headers = {
     "Authorization": "Bearer YOUR_API_KEY",
@@ -167,6 +167,52 @@ data = {
 
 response = requests.post(url, headers=headers, json=data)
 print(response.json())
+```
+
+```ts TypeScript SDK
+import createRelaceClient from '@relace-ai/agent-client'
+
+const client = createRelaceClient({ apiKey: process.env.RELACE_API_KEY! })
+
+const repo_id = '123e4567-e89b-12d3-a456-426614174000'
+await client.POST('/repo/{repo_id}/update', {
+  params: { path: { repo_id } },
+  body: {
+    source: {
+      type: 'diff',
+      operations: [
+        { type: 'write', filename: 'src/search.ts', content: '// ...' },
+        {
+          type: 'rename',
+          old_filename: 'src/utils.ts',
+          new_filename: 'src/helpers.ts',
+        },
+        { type: 'delete', filename: 'old-file.js' },
+      ],
+    },
+  },
+})
+```
+
+```python Python SDK
+from relace_agent_client import AuthenticatedClient
+from relace_agent_client.api.default import update_repo_contents_repo_repo_id_update_post
+from relace_agent_client.models import RepoUpdateRequest, RepoUpdateDiff, FileWriteOperation, FileRenameOperation, FileDeleteOperation
+
+client = AuthenticatedClient(base_url="https://api.relace.run/v1", token="YOUR_API_KEY")
+req = RepoUpdateRequest(
+    source=RepoUpdateDiff(
+        type_="diff",
+        operations=[
+            FileWriteOperation(type_="write", filename="src/search.ts", content="// ..."),
+            FileRenameOperation(type_="rename", old_filename="src/utils.ts", new_filename="src/helpers.ts"),
+            FileDeleteOperation(type_="delete", filename="old-file.js"),
+        ],
+    )
+)
+with client as c:
+    info = update_repo_contents_repo_repo_id_update_post.sync(client=c, repo_id="123e4567-e89b-12d3-a456-426614174000", body=req)
+print(info)
 ```
 
 </RequestExample>

--- a/docs.json
+++ b/docs.json
@@ -103,6 +103,7 @@
                 "pages": [
                   "api-reference/repos/list",
                   "api-reference/repos/create",
+                  "api-reference/repos/get",
                   "api-reference/repos/update",
                   "api-reference/repos/delete",
                   "api-reference/repos/clone"
@@ -112,7 +113,8 @@
                 "group": "Semantic Retrieval",
                 "pages": [
                   "api-reference/repos/retrieve",
-                  "api-reference/repos/ask"
+                  "api-reference/repos/ask",
+                  "api-reference/repos/search"
                 ]
               }
             ]

--- a/docs/repos/quickstart.mdx
+++ b/docs/repos/quickstart.mdx
@@ -17,7 +17,7 @@ Start by transferring your existing repositories to Relace.
 ```python From GitHub
 import requests
 
-url = "https://api.relace.ai/v1/repo"
+url = "https://api.relace.run/v1/repo"
 headers = {
     "Authorization": "Bearer YOUR_API_KEY",
     "Content-Type": "application/json"
@@ -40,7 +40,7 @@ print(f"Repository created with ID: {repo['repo_id']}")
 ```python From Files
 import requests
 
-url = "https://api.relace.ai/v1/repo"
+url = "https://api.relace.run/v1/repo"
 headers = {
     "Authorization": "Bearer YOUR_API_KEY",
     "Content-Type": "application/json"
@@ -65,6 +65,61 @@ repo = response.json()
 print(f"Repository created with ID: {repo['repo_id']}")
 ```
 
+```ts TypeScript SDK
+import createRelaceClient from '@relace-ai/agent-client'
+
+const client = createRelaceClient({ apiKey: process.env.RELACE_API_KEY! })
+
+// From Git
+await client.POST('/repo', {
+  body: {
+    source: {
+      type: 'git',
+      url: 'https://github.com/username/repository-name',
+      branch: 'main',
+    },
+  },
+})
+
+// From files
+await client.POST('/repo', {
+  body: {
+    source: {
+      type: 'files',
+      files: [
+        {
+          filename: 'src/main.py',
+          content: "def main():\n    print('Hello')\n",
+        },
+      ],
+    },
+  },
+})
+```
+
+```python Python SDK
+from relace_agent_client import AuthenticatedClient
+from relace_agent_client.api.default import create_repo_repo_post
+from relace_agent_client.models import RepoCreateRequest, RepoCreateGitSource, RepoCreateFilesSource, File as ModelFile
+
+client = AuthenticatedClient(base_url="https://api.relace.run/v1", token="YOUR_API_KEY")
+
+# From Git
+with client as c:
+        created = create_repo_repo_post.sync(
+                client=c,
+                body=RepoCreateRequest(source=RepoCreateGitSource(type_="git", url="https://github.com/username/repository-name", branch="main")),
+        )
+
+# From files
+files = [ModelFile(filename="src/main.py", content="print('Hello')\n")]
+with client as c:
+        created = create_repo_repo_post.sync(
+                client=c,
+                body=RepoCreateRequest(source=RepoCreateFilesSource(type_="files", files=files)),
+        )
+```
+
 </CodeGroup>
 
 Keep track of the Relace `repo_id` in your database for future reference. You can optionally include a `metadata` parameter to add any properties of repos you want to maintain.
@@ -78,7 +133,7 @@ Now that your repositories live in Relace, you can integrate them with your agen
 ```python
 import requests
 
-url = f"https://api.relace.ai/v1/repo/{repo_id}/clone"
+url = f"https://api.relace.run/v1/repo/{repo_id}/clone"
 headers = {
     "Authorization": "Bearer YOUR_API_KEY"
 }
@@ -92,6 +147,29 @@ for file in repo_files['files']:
     print(f"Content: {file['content'][:100]}...")  # First 100 characters
 ```
 
+```ts TypeScript SDK
+import createRelaceClient from '@relace-ai/agent-client'
+
+const client = createRelaceClient({ apiKey: process.env.RELACE_API_KEY! })
+const { data: clone } = await client.GET('/repo/{repo_id}/clone', {
+  params: { path: { repo_id } },
+})
+for (const f of clone?.files ?? []) {
+  console.log(f.filename, f.content.length)
+}
+```
+
+```python Python SDK
+from relace_agent_client import AuthenticatedClient
+from relace_agent_client.api.default import clone_repo_repo_repo_id_clone_get
+
+client = AuthenticatedClient(base_url="https://api.relace.run/v1", token="YOUR_API_KEY")
+with client as c:
+        clone = clone_repo_repo_repo_id_clone_get.sync(client=c, repo_id=repo_id)
+for f in (clone.files or []):
+        print(f.filename, len(f.content))
+```
+
 After your agent modifies files, push the changes back to Relace. You can either update specific files or overwrite all repository content.
 
 <CodeGroup>
@@ -100,7 +178,7 @@ After your agent modifies files, push the changes back to Relace. You can either
 import requests
 
 # Apply specific file operations using diff mode
-url = f"https://api.relace.ai/v1/repo/{repo_id}/update"
+url = f"https://api.relace.run/v1/repo/{repo_id}/update"
 headers = {
     "Authorization": "Bearer YOUR_API_KEY",
     "Content-Type": "application/json"
@@ -136,7 +214,7 @@ print(f"Applied diff operations: {response.json()}")
 import requests
 
 # Overwrite all repository content
-url = f"https://api.relace.ai/v1/repo/{repo_id}/update"
+url = f"https://api.relace.run/v1/repo/{repo_id}/update"
 headers = {
     "Authorization": "Bearer YOUR_API_KEY",
     "Content-Type": "application/json"
@@ -162,6 +240,46 @@ response = requests.post(url, headers=headers, json=data)
 print(f"Overwrote repository: {response.json()}")
 ```
 
+```ts TypeScript SDK (Diff)
+import createRelaceClient from '@relace-ai/agent-client'
+const client = createRelaceClient({ apiKey: process.env.RELACE_API_KEY! })
+await client.POST('/repo/{repo_id}/update', {
+  params: { path: { repo_id } },
+  body: {
+    source: {
+      type: 'diff',
+      operations: [
+        {
+          type: 'write',
+          filename: 'src/main.py',
+          content: "print('updated')\n",
+        },
+        { type: 'delete', filename: 'old-unused-file.py' },
+      ],
+    },
+  },
+})
+```
+
+```python Python SDK (Diff)
+from relace_agent_client import AuthenticatedClient
+from relace_agent_client.api.default import update_repo_contents_repo_repo_id_update_post
+from relace_agent_client.models import RepoUpdateRequest, RepoUpdateDiff, FileWriteOperation, FileDeleteOperation
+
+client = AuthenticatedClient(base_url="https://api.relace.run/v1", token="YOUR_API_KEY")
+req = RepoUpdateRequest(
+        source=RepoUpdateDiff(
+                type_="diff",
+                operations=[
+                        FileWriteOperation(type_="write", filename="src/main.py", content="print('updated')\n"),
+                        FileDeleteOperation(type_="delete", filename="old-unused-file.py"),
+                ],
+        )
+)
+with client as c:
+        update_repo_contents_repo_repo_id_update_post.sync(client=c, repo_id=repo_id, body=req)
+```
+
 </CodeGroup>
 
 ## 3. Use Built-In Semantic Retrieval
@@ -171,7 +289,7 @@ Repositories stored in Relace get automatically indexed with our code embedding 
 ```python
 import requests
 
-url = f"https://api.relace.ai/v1/repo/{repo_id}/retrieve"
+url = f"https://api.relace.run/v1/repo/{repo_id}/retrieve"
 headers = {
     "Authorization": "Bearer YOUR_API_KEY",
     "Content-Type": "application/json"
@@ -182,6 +300,36 @@ data = {
 
 response = requests.post(url, headers=headers, json=data)
 results = response.json()["results"]
+```
+
+```ts TypeScript SDK
+import createRelaceClient from '@relace-ai/agent-client'
+
+const client = createRelaceClient({ apiKey: process.env.RELACE_API_KEY! })
+const { data } = await client.POST('/repo/{repo_id}/retrieve', {
+  params: { path: { repo_id } },
+  body: {
+    query: 'Add a user profile component',
+    include_content: true,
+    score_threshold: 0.3,
+  },
+})
+console.log(data?.results)
+```
+
+```python Python SDK
+from relace_agent_client import AuthenticatedClient
+from relace_agent_client.api.default import retrieve_relevant_content_repo_repo_id_retrieve_post
+from relace_agent_client.models import RepoRetrieveRequest
+
+client = AuthenticatedClient(base_url="https://api.relace.run/v1", token="YOUR_API_KEY")
+with client as c:
+        r = retrieve_relevant_content_repo_repo_id_retrieve_post.sync(
+                client=c,
+                repo_id=repo_id,
+                body=RepoRetrieveRequest(query="Add a user profile component", include_content=True, score_threshold=0.3),
+        )
+print(r)
 ```
 
 You can parse the results the same way you do with direct calls to the reranker.

--- a/docs/repos/semantic-understanding.mdx
+++ b/docs/repos/semantic-understanding.mdx
@@ -38,7 +38,7 @@ The Ask endpoint returns natural language explanations perfect for understanding
 import requests
 
 repo_id = "your-repo-id"
-url = f"https://api.relace.ai/v1/repo/{repo_id}/ask"
+url = f"https://api.relace.run/v1/repo/{repo_id}/ask"
 headers = {
     "Authorization": "Bearer YOUR_API_KEY",
     "Content-Type": "application/json"
@@ -70,7 +70,7 @@ The Retrieve endpoint returns ranked files with relevance scores, giving you pre
 import requests
 
 repo_id = "your-repo-id"
-url = f"https://api.relace.ai/v1/repo/{repo_id}/retrieve"
+url = f"https://api.relace.run/v1/repo/{repo_id}/retrieve"
 headers = {
     "Authorization": "Bearer YOUR_API_KEY",
     "Content-Type": "application/json"


### PR DESCRIPTION
- Added TypeScript and Python SDK examples for the following endpoints:
  - `POST /repo/{repo_id}/ask`
  - `GET /repo/{repo_id}/clone`
  - `POST /repo`
  - `DELETE /repo/{repo_id}`
  - `GET /repo`
  - `POST /repo/{repo_id}/retrieve`
  - `POST /repo/{repo_id}/update`
  - `POST /repo/{repo_id}/search`
- Changed API URLs in openapi.json and various .mdx files to use relace.run
- Improved descriptions and notes for clarity on usage